### PR TITLE
RBAC Resources for Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,21 +76,17 @@ metadata:
   name: opslevel-payload-check
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - deployments
+    - ""
+    - apps
+    - extensions
+    - batch
+    - networking
+  resources: 
+    - "*"
   verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - get
-  - list
-  - watch
+    - get
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/README.md
+++ b/README.md
@@ -70,6 +70,47 @@ docker run -v $(pwd)/opslevel.yaml:/opslevel.yaml <docker image you built> -c /o
 Configure the ConfigMap and Deploy it to your kubernetes cluster.
 
 ```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opslevel-payload-check
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: opslevel-payload-check
+roleRef: 
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: opslevel-payload-check
+subjects:
+- kind: ServiceAccount
+  name: opslevel-payload-check
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opslevel-payload-check
+  namespace: default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -112,6 +153,7 @@ spec:
       labels:
         app: opslevel-payload-check
     spec:
+      serviceAccountName: opslevel-payload-check
       containers:
         - name: web
           image: <replace me with location where you published the image>


### PR DESCRIPTION
Adding ClusterRole, ClusterRoleBinding, and ServiceAccount to support RBAC permissions needed for k8s integration.